### PR TITLE
Add Docker-based development environment and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ $RECYCLE.BIN/
 # End of https://www.gitignore.io/api/node,macos,linux,windows,webstorm,visualstudiocode
 
 firebase-adminsdk.json
+local-google-credentials-heroku.json

--- a/README.md
+++ b/README.md
@@ -3,37 +3,26 @@
 The Emerald City Resource Guide (ECRG, [http://www.emeraldcityresourceguide.org/](http://www.emeraldcityresourceguide.org/)) is a directory of social service organizations located in Seattle.  The first hard copy of the guide was published by local non-profit, [Real Change](https://www.realchangenews.org/), in April, 2018, in the hopes of providing an easy reference guide for individuals who may not have access to a computer. v1 of the online version of the guide was released in January, 2019, with the intention of providing the means for updating the guide on a more frequent basis and a creating a dynamic UI for those with access to the internet.
 
 ## Getting Started
-To run this application on your local machine, you will need to set up a local relational database, install the necessary dependencies, and set up your own environmental variables file.
 
-### Database
-*Local Set Up*  
+Follow these steps to set up a local development environment:
+1. Install [docker and docker-compose](https://docs.docker.com/get-docker/)
+2. Create a file named `.env` in your clone of this repository with two lines, one setting `FIREBASE_CONFIG` and one setting `GOOGLE_CONFIG`. Copy-and-paste the values from https://dashboard.heroku.com/apps/emerald-city-guide/settings, but make sure to remove newlines.
 
-1. Create your database - within Postgres: 'CREATE <database_name>;'
-2. Populate `DATABASE_URL` in `.env` file with the url for your local database (e.g. postgres://localhost:5432/DATABASE_NAME)
-3. Create schema - `npx knex migrate:latest`
-4. Populate tables - `npx knex seed:run` 
+    ```
+    FIREBASE_CONFIG={ apiKey...
+    GOOGLE_CONFIG={ "type":...
+    ```
 
-Depending on how you have set up Postgres on your machine, you may need to manually initialize the connection to Postgres when running your code locally using the following command in CLI: 'pg_ctl -D /usr/local/var/postgres start'.
-
-*Production*  
-To access the production database hosted by Heroku, run 'heroku pg:psql -—app emerald-city-guide' from within CLI and follow login prompts as directed (this is assuming that you have been added as a collaborator to the site on Heroku).
-
-### Dependencies
-From within the CLI, install the following npms:
-
-- dotenv
-- ejs
-- express
-- nodemon
-- pg
-
-### Environmental Variables
-Within your .env file, you must declare the following variables:
-- DATABASE_URL - the url for your local database (e.g. postgres://localhost:5432/DATABASE_NAME)
-- PORT - the port you'll use to run the app locally (e.g. 8080)
+3. Install dependencies and set up the DB with `docker-compose run --rm node sh -c "npm install && npm run db:init"`
+4. Launch the server with `docker-compose up` and visit http://localhost:8080/
 
 ## Testing
-Local testing is conducted using mocha and chai.  The test file within this repo is intended to cover the server methods that transform the user inputs in the search form into a SQL query and then retrieves the corresponding records from the database.
+Local testing is conducted using mocha and chai. Run the tests using `docker-compose run --rm node npm run test`
+
+The test file within this repo is intended to cover the server methods that transform the user inputs in the search form into a SQL query and then retrieves the corresponding records from the database.
+
+## Production
+To access the production database hosted by Heroku, run `heroku pg:psql -—app emerald-city-guide` from within CLI and follow login prompts as directed (this is assuming that you have been added as a collaborator to the site on Heroku).
 
 ## Upcoming Features
 - Embedded Google Maps and location filtering

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  node:
+    image: node:11.4.0
+    user: node
+    ports:
+      - "8080:8080"
+    environment:
+      DATABASE_URL: "postgres://emerald-city-resource-guide:password@postgres:5432/emerald-city-resource-guide"
+      PGSSLMODE: disable
+      GOOGLE_APPLICATION_CREDENTIALS: "/code/local-google-credentials-heroku.json"
+      FIREBASE_CONFIG:
+      GOOGLE_CONFIG:
+    working_dir: /code
+    volumes:
+      - .:/code
+    depends_on:
+      - postgres
+    command: npm start
+
+  postgres:
+    image: postgres:14.2
+    environment:
+      POSTGRES_USER: emerald-city-resource-guide
+      POSTGRES_PASSWORD: password

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "mocha",
     "test:watch": "mocha --watch ./test ./",
     "preinstall": "node preinstall.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "db:init": "npx knex migrate:latest && npx knex seed:run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a dev environment using Docker and docker-compose to simplify onboarding for new developers. I also added an `.editorconfig` file to standardize on code style.

Output when I tested this:
```
$ docker-compose run --rm node sh -c "npm install && npm run db:init"
Creating network "emerald-city-resource-guide_default" with the default driver
Creating emerald-city-resource-guide_postgres_1 ... done
Creating emerald-city-resource-guide_node_run   ... done

> emerald-city-resource-guide@1.0.0 preinstall /code
> node preinstall.js

> grpc@1.20.0 install /code/node_modules/@firebase/firestore/node_modules/grpc
> node-pre-gyp install --fallback-to-build --library=static_library

node-pre-gyp WARN Using needle for node-pre-gyp https download
[grpc] Success: "/code/node_modules/@firebase/firestore/node_modules/grpc/src/node/extension_binary/node-v67-linux-x64-glibc/grpc_node.node" is installed via remote

> grpc@1.24.4 install /code/node_modules/grpc
> node-pre-gyp install --fallback-to-build --library=static_library

node-pre-gyp WARN Using needle for node-pre-gyp https download
[grpc] Success: "/code/node_modules/grpc/src/node/extension_binary/node-v67-linux-x64-glibc/grpc_node.node" is installed via remote

> protobufjs@6.8.8 postinstall /code/node_modules/protobufjs
> node scripts/postinstall

> nodemon@1.18.10 postinstall /code/node_modules/nodemon
> node bin/postinstall || exit 0

Love nodemon? You can now support the project via the open collective:
 > https://opencollective.com/nodemon/donate

npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.13 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

added 798 packages from 880 contributors and audited 803 packages in 7.122s
found 105 vulnerabilities (7 low, 28 moderate, 59 high, 11 critical)
  run `npm audit fix` to fix them, or `npm audit` for details

> emerald-city-resource-guide@1.0.0 db:init /code
> npx knex migrate:latest && npx knex seed:run

Using environment: development
Batch 1 run: 10 migrations
Using environment: development
Ran 4 seed files

$ docker-compose up
emerald-city-resource-guide_postgres_1 is up-to-date
Creating emerald-city-resource-guide_node_1 ... done                                                                                                                                                                                            [1/9790]
Attaching to emerald-city-resource-guide_postgres_1, emerald-city-resource-guide_node_1
postgres_1  | The files belonging to this database system will be owned by user "postgres".
postgres_1  | This user must also own the server process.
postgres_1  |
postgres_1  | The database cluster will be initialized with locale "en_US.utf8".
postgres_1  | The default database encoding has accordingly been set to "UTF8".
postgres_1  | The default text search configuration will be set to "english".
postgres_1  |
postgres_1  | Data page checksums are disabled.
postgres_1  |
postgres_1  | fixing permissions on existing directory /var/lib/postgresql/data ... ok
postgres_1  | creating subdirectories ... ok
postgres_1  | selecting dynamic shared memory implementation ... posix
postgres_1  | selecting default max_connections ... 100
postgres_1  | selecting default shared_buffers ... 128MB
postgres_1  | selecting default time zone ... Etc/UTC
postgres_1  | creating configuration files ... ok
postgres_1  | running bootstrap script ... ok
postgres_1  | performing post-bootstrap initialization ... ok
postgres_1  | initdb: warning: enabling "trust" authentication for local connections
postgres_1  | You can change this by editing pg_hba.conf or using the option -A, or
postgres_1  | --auth-local and --auth-host, the next time you run initdb.
postgres_1  | syncing data to disk ... ok
postgres_1  |
postgres_1  |
postgres_1  | Success. You can now start the database server using:
postgres_1  |
postgres_1  |     pg_ctl -D /var/lib/postgresql/data -l logfile start
postgres_1  |
postgres_1  | waiting for server to start....2022-06-09 02:35:53.121 UTC [49] LOG:  starting PostgreSQL 14.2 (Debian 14.2-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgres_1  | 2022-06-09 02:35:53.123 UTC [49] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres_1  | 2022-06-09 02:35:53.132 UTC [50] LOG:  database system was shut down at 2022-06-09 02:35:52 UTC
postgres_1  | 2022-06-09 02:35:53.138 UTC [49] LOG:  database system is ready to accept connections
postgres_1  |  done
postgres_1  | server started
postgres_1  | CREATE DATABASE
postgres_1  |
postgres_1  |
postgres_1  | /usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
postgres_1  |
postgres_1  | 2022-06-09 02:35:53.343 UTC [49] LOG:  received fast shutdown request
postgres_1  | waiting for server to shut down....2022-06-09 02:35:53.347 UTC [49] LOG:  aborting any active transactions
postgres_1  | 2022-06-09 02:35:53.348 UTC [49] LOG:  background worker "logical replication launcher" (PID 56) exited with exit code 1
postgres_1  | 2022-06-09 02:35:53.348 UTC [51] LOG:  shutting down
postgres_1  | 2022-06-09 02:35:53.369 UTC [49] LOG:  database system is shut down
postgres_1  |  done
postgres_1  | server stopped
postgres_1  |
postgres_1  | PostgreSQL init process complete; ready for start up.
postgres_1  |
postgres_1  | 2022-06-09 02:35:53.458 UTC [1] LOG:  starting PostgreSQL 14.2 (Debian 14.2-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgres_1  | 2022-06-09 02:35:53.458 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres_1  | 2022-06-09 02:35:53.458 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgres_1  | 2022-06-09 02:35:53.464 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres_1  | 2022-06-09 02:35:53.474 UTC [63] LOG:  database system was shut down at 2022-06-09 02:35:53 UTC
postgres_1  | 2022-06-09 02:35:53.480 UTC [1] LOG:  database system is ready to accept connections
node_1      |
node_1      | > emerald-city-resource-guide@1.0.0 start /code
node_1      | > node server.js
node_1      |
node_1      | Listening on 8080

```