### PR TITLE
Update "Copy Requests" page

### DIFF
--- a/public/styles/base.css
+++ b/public/styles/base.css
@@ -561,7 +561,7 @@ span.emphasis {
 	margin: 2vw;
 }
 
-#remaining-pickup {
+#total-requests {
 	margin: 1vw auto;
 	text-align: center;
 }

--- a/server.js
+++ b/server.js
@@ -915,18 +915,23 @@ app.put("/admin/addconfirmation", isAuthenticated, function (req, res) {
 });
 
 app.get("/admin/copyrequests", isAuthenticated, function (req, res) {
-  let SQL =
+  const SQL =
     "SELECT * FROM requests WHERE picked_up='f' AND deleted='f' ORDER BY LOWER(organization_name);";
-  let copyRequests = "SELECT SUM(number) FROM requests WHERE deleted='f';"
-  let pendingRequests;
+  const copyRequests = `
+    SELECT
+      SUM(number) AS total_requests,
+      SUM(CASE WHEN picked_up = 't' THEN number ELSE 0 END) AS total_picked_up
+    FROM requests
+    WHERE deleted='f'
+  `;
 
   return doQuery(SQL)
   .then(function(results) {
-    pendingRequests = results;
+    const pendingRequests = results;
     return doQuery(copyRequests).then(function(results) {
       res.render("./pages/auth/copy-requests.ejs", {
         requests: pendingRequests.rows,
-        total: results.rows[0].sum
+        ...results.rows[0],
      });
     });
   });

--- a/views/pages/auth/copy-requests.ejs
+++ b/views/pages/auth/copy-requests.ejs
@@ -6,8 +6,7 @@
   <%- include('../../layout/header') %>
   <div>
     <%- include('../auth/sidebar.ejs') %>
-<!--     <h2 id="remaining-pickup">Remaining Number of Guides to be Picked Up: <span id="guide-count"></span></h2> -->
-    <h2 id="remaining-pickup">Number of copies available: <span id="guide-count"><%- 50000 - total %></span></h2>
+    <h2 id="total-requests"><%- total_requests %> total copies requested, <%- total_picked_up %> picked up</h2>
     <button type="submit" class="download-requests-button" >Download Requests</button>
 
     <div class="copy-request-container">
@@ -41,14 +40,6 @@
     </div>
     <%- include('../../layout/footer') %>
     <script>
-      // count # of guides still to be picked up
-/*       let sum = 0;
-      const numberOfCopies = 50000;
-      $(".guide-number").each(function () {
-        sum += parseInt($(this).html(), 10) || 0;
-      });
-
-      $("#guide-count").text(numberOfCopies - sum); */
 
       $('.pick-up-button').on('click', function(e) {
         $.post('/admin/request/pickup',


### PR DESCRIPTION
As requested by Tye, instead of showing the number of copies available (which assumes there's always 50,000 copies total), we should show the number of copies requested and the number of copies picked up.