### PR TITLE
Increase concurrency limits

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,8 +22,8 @@ processes = []
   protocol = "tcp"
   script_checks = []
   [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
+    hard_limit = 200
+    soft_limit = 100
     type = "connections"
 
   [[services.ports]]


### PR DESCRIPTION
The app is crashing, and I'm seeing the error "Instance reached connections hard limit of 25" in the logs.  It should be able to handle a lot more than that, though I haven't benchmarked it to tell, so I'm increasingly the hard limit to 200.