### PR TITLE
Fix deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax = docker/dockerfile:1
+# This Dockerfile is only used for deploying to fly.io.
+# See docker-compose.yml for the dev environment
+
+# This should match the version in docker-compose.yml
+ARG NODE_VERSION=11.4.0
+FROM node:${NODE_VERSION} AS build
+
+# Node.js app lives here
+WORKDIR /app
+
+# Copy application code
+COPY . .
+
+# Install node modules
+RUN npm ci --production
+
+FROM node:${NODE_VERSION}-slim
+
+WORKDIR /app
+
+# Set production environment
+ENV NODE_ENV=production
+
+LABEL fly_launch_runtime="Node.js"
+
+# Copy built application
+COPY --from=build /app /app
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 8080
+CMD [ "npm", "run", "start" ]

--- a/fly.toml
+++ b/fly.toml
@@ -5,10 +5,6 @@ kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []
 
-[build]
-  #image = "node:11.4.0"
-  builder = "heroku/buildpacks:20"
-
 [env]
 
 [experimental]


### PR DESCRIPTION
Deploy is broken, apparently because the `heroku/buildpack:20` image was updated. This switches to a Dockerfile-based deploy, as recommended at https://fly.io/docs/getting-started/troubleshooting/#did-your-buildpack-based-deploy-stop-working